### PR TITLE
Enhance timezone management in BarcodeScreen

### DIFF
--- a/frontend/lib/services/tz_service.dart
+++ b/frontend/lib/services/tz_service.dart
@@ -1,0 +1,15 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+class TzService {
+  static const _key = 'user_tz';
+
+  Future<String?> getTz() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getString(_key);
+  }
+
+  Future<void> setTz(String tz) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_key, tz);
+  }
+}


### PR DESCRIPTION
 * Saves user TZ, reloads on app start, and immediately refreshes Summary & Meals when TZ changes.
* Displays active TZ in headers and tooltip for clarity.
* Idempotent UI-only change; no backend or routing updates.

**Changed files:**

* `frontend/lib/services/tz_service.dart`
* `frontend/lib/screens/barcode_screen.dart`

**Test plan:**

1. `flutter analyze` → 0 issues.
2. Barcode → tap 🌐 → pick a new TZ → SnackBar appears; **both** Summary & Meals headers show new TZ; list refreshes.
3. Reload app → TZ persists.
4. Toggle Today/Yesterday → Summary & Meals remain aligned in the selected TZ.
