### PR TITLE
Implement CSV and JSON export functionality in BarcodeScreen

### DIFF
--- a/frontend/lib/services/export_service.dart
+++ b/frontend/lib/services/export_service.dart
@@ -1,0 +1,80 @@
+import 'dart:convert';
+
+class ExportService {
+  /// CSV: one row per meal for [date] in [tz].
+  /// Columns: date,tz,id,food_name,brand,grams,calories,protein,carbs,fat,fiber,sugar,sodium,meal_time,notes
+  static String csvForDay({
+    required String date,
+    required String tz,
+    required Map<String, dynamic> summary,
+    required List<Map<String, dynamic>> meals,
+  }) {
+    const headers = [
+      'date',
+      'tz',
+      'id',
+      'food_name',
+      'brand',
+      'grams',
+      'calories',
+      'protein',
+      'carbs',
+      'fat',
+      'fiber',
+      'sugar',
+      'sodium',
+      'meal_time',
+      'notes',
+    ];
+    final lines = <String>[];
+    lines.add(headers.join(','));
+    for (final m in meals) {
+      final totals = (m['totals'] as Map?) ?? const {};
+      String esc(dynamic v) {
+        final s = (v == null) ? '' : v.toString();
+        return _csvEscape(s);
+      }
+      lines.add([
+        esc(date),
+        esc(tz),
+        esc(m['id']),
+        esc(m['food_name']),
+        esc(m['brand']),
+        esc(m['quantity']),
+        esc(totals['calories']),
+        esc(totals['protein']),
+        esc(totals['carbs']),
+        esc(totals['fat']),
+        esc(totals['fiber']),
+        esc(totals['sugar']),
+        esc(totals['sodium']),
+        esc(m['meal_time']),
+        esc(m['notes']),
+      ].join(','));
+    }
+    return lines.join('\r\n');
+  }
+
+  /// JSON: bundles summary and meals for [date] in [tz].
+  static String jsonForDay({
+    required String date,
+    required String tz,
+    required Map<String, dynamic> summary,
+    required List<Map<String, dynamic>> meals,
+  }) {
+    final payload = {
+      'date': date,
+      'tz': tz,
+      'summary': summary, // includes totals/units/entries from API
+      'meals': meals,
+    };
+    return const JsonEncoder.withIndent('  ').convert(payload);
+  }
+
+  static String _csvEscape(String s) {
+    // Double quotes and wrap if field contains comma/quote/newline
+    final needsWrap = s.contains(RegExp(r'[",\r\n]'));
+    final body = s.replaceAll('"', '""');
+    return needsWrap ? '"$body"' : body;
+  }
+}

--- a/frontend/lib/services/file_saver.dart
+++ b/frontend/lib/services/file_saver.dart
@@ -1,0 +1,8 @@
+// Conditional import wrapper to keep Android builds happy later.
+import 'file_saver_stub.dart'
+    if (dart.library.html) 'file_saver_web.dart' as impl;
+
+Future<void> saveTextFile(String filename, String text,
+    {String mimeType = 'text/plain'}) {
+  return impl.saveTextFile(filename, text, mimeType: mimeType);
+}

--- a/frontend/lib/services/file_saver_stub.dart
+++ b/frontend/lib/services/file_saver_stub.dart
@@ -1,0 +1,8 @@
+import 'dart:async';
+
+Future<void> saveTextFile(String filename, String text,
+    {String mimeType = 'text/plain'}) {
+  return Future.error(
+    UnsupportedError('Saving files is not supported on this platform yet.'),
+  );
+}

--- a/frontend/lib/services/file_saver_web.dart
+++ b/frontend/lib/services/file_saver_web.dart
@@ -1,0 +1,16 @@
+import 'dart:convert';
+import 'dart:html' as html; // ignore: avoid_web_libraries_in_flutter, deprecated_member_use
+
+
+Future<void> saveTextFile(String filename, String text,
+    {String mimeType = 'text/plain'}) async {
+  final bytes = utf8.encode(text);
+  final blob = html.Blob([bytes], mimeType);
+  final url = html.Url.createObjectUrlFromBlob(blob);
+  final anchor = html.AnchorElement(href: url)..download = filename;
+  // Ensure it's attached long enough to click in some browsers
+  html.document.body?.append(anchor);
+  anchor.click();
+  anchor.remove();
+  html.Url.revokeObjectUrl(url);
+}


### PR DESCRIPTION
# feat(export): Export Day as CSV/JSON (TZ-aware)

## Summary

Add client-side export for the selected **local day** using the active **IANA timezone**. Users can choose CSV or JSON from a bottom sheet. No backend or routing changes.

## What & Why

* **CSV**: one row per meal (includes per-entry totals).
* **JSON**: structured bundle `{ date, tz, summary, meals }` for audit/sharing.
* **TZ-aware**: filenames and data reflect the currently selected timezone/day.
* **UX**: export button in the Barcode screen AppBar → bottom sheet (CSV/JSON).

## Changes

* **New** `ExportService` to format CSV/JSON.
* **New** `FileSaver` with conditional import:

  * `file_saver_web.dart` (web implementation via `dart:html`).
  * `file_saver_stub.dart` (non-web placeholder).
* **UI** `barcode_screen.dart`: export action + bottom sheet; uses existing API calls.
* **ApiClient**:

  * Fixed base URI usage (avoid `/api/api/...`).
  * `getMealsForDate` parsing now handles **bare list** and **paginated** (`{results: [...]}`) responses.
  * Kept **`getDailySummary(date: String, tz: String)`** as source of truth; **`getSummary`** is a thin alias.

## Backward compatibility / Guardrails

* **No backend or route changes.**
* **ApiClient method signatures** remain compatible with the hand-off.
* Minimal, idempotent diffs; unrelated files untouched.

## Changed files

* `frontend/lib/services/export_service.dart` **(new)**
* `frontend/lib/services/file_saver.dart` **(new, conditional wrapper)**
* `frontend/lib/services/file_saver_stub.dart` **(new, non-web stub)**
* `frontend/lib/services/file_saver_web.dart` **(new, web impl)**
* `frontend/lib/screens/barcode_screen.dart` *(export UI + calls)*
* `frontend/lib/services/api_client.dart` *(URI fix; resilient meals parsing; `getSummary` alias)*

## Test Plan

* `flutter analyze` → **0 issues**.
* **Web App:**

  1. Pick a date & TZ → tap download → **Export CSV** → file downloads; open and verify one row/meal and totals present.
  2. Tap download → **Export JSON** → file downloads; verify `{date, tz, summary, meals}` structure.
  3. Change TZ and/or date → export again → filenames and contents reflect the current selection.
  4. Day with many meals (pagination) → both exports still succeed.
* **Error handling:** remove/expire token → export → Snackbar shows clear failure; no crash.

## Follow-ups (optional)

* Mobile export: add Android/iOS implementation (e.g., `share_plus` / `path_provider`) behind the same `FileSaver` wrapper.
* “Export last 7 days (zip)” quick iteration.

---
